### PR TITLE
Adding safeguard for files without support from the library used.

### DIFF
--- a/src/adalbertogonzaga/mypicslocation/MyPicturesLocationWindow.java
+++ b/src/adalbertogonzaga/mypicslocation/MyPicturesLocationWindow.java
@@ -351,7 +351,14 @@ public class MyPicturesLocationWindow extends JFrame {
 			
 			if(confirmation == JOptionPane.YES_OPTION) {
 				System.out.println("YES");
-				PicturesUtil.insertGeolocation(location, createACopy, getLatitude(), getLongitude() );
+				try {
+					PicturesUtil.insertGeolocation(location, createACopy, getLatitude(), getLongitude() );
+				} catch (ClassCastException e) {
+					JOptionPane.showMessageDialog(this, "It looks like I can't handle a file. \nCheck if there's Exif support for the file(s) you're trying to use.", "Error handling file metadata", 0);
+					e.printStackTrace();
+					return;
+				}
+				
 				JOptionPane.showMessageDialog(this, "Done!", "Finished", JOptionPane.INFORMATION_MESSAGE);
 			} else {
 				System.out.println("NO");

--- a/src/adalbertogonzaga/mypicslocation/PicturesUtil.java
+++ b/src/adalbertogonzaga/mypicslocation/PicturesUtil.java
@@ -80,7 +80,7 @@ public class PicturesUtil {
 	 * @param latitude A Double value representing the Latitude. Desirable format: (-)50.123456
 	 * @param longitude A Double value representing the Longitude. Desirable format: (-)50.123456
 	 */
-	public static void insertGeolocation(File sourceData, Boolean createACopy, double latitude, double longitude) {
+	public static void insertGeolocation(File sourceData, Boolean createACopy, double latitude, double longitude) throws ClassCastException{
 		
 		
 		ArrayList<String> sourceFiles = new ArrayList<String>();

--- a/src/adalbertogonzaga/photoplaces/exif/ExifGPSUtil.java
+++ b/src/adalbertogonzaga/photoplaces/exif/ExifGPSUtil.java
@@ -122,14 +122,22 @@ public class ExifGPSUtil {
 	 * @param latitude
 	 * @param longitude
 	 */
-	public static void insertGPSLocationIntoFile(File originalFile, File destinationFile, Double latitude, Double longitude) {
+	public static void insertGPSLocationIntoFile(File originalFile, File destinationFile, Double latitude, Double longitude) throws ClassCastException{
 
 		OutputStream os = null;
 		try {
 			TiffOutputSet outputSet = null;
 			// note that metadata might be null if no metadata is found.
 			IImageMetadata metadata = Sanselan.getMetadata(originalFile);
-			JpegImageMetadata jpegMetadata = (JpegImageMetadata) metadata;
+			JpegImageMetadata jpegMetadata = null;
+			try {
+				jpegMetadata = (JpegImageMetadata) metadata;
+			} catch (ClassCastException e) {
+				throw e;
+			} catch (Exception e) {
+				// TODO handle this
+				e.printStackTrace();
+			}
 			if (null != jpegMetadata) {
 				// note that exif might be null if no Exif metadata is found.
 				TiffImageMetadata exif = jpegMetadata.getExif();


### PR DESCRIPTION
I'm throwing exceptions around, but this gives a feedback to the user about a problem when trying to add geolocation data to the file.

One thing to consider is the removal of PNG as a supported file type, but that doesn't invalidate my code here, I believe. 

EDIT: actually, if PNG should be removed, yeah, maybe this code should not be merged. Let me know...